### PR TITLE
services fixed for compatability with old 1.7 prestashop versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,10 @@
 ### Changed
 - Validations added for back office address form
 - Functionality added, show API error messages at front end
+
+## [3.1.4] - 2021-02-02
+
+### Changed
+- Validation added for back office product page on deleted carriers(do not show deleted carrier)
+- Name changed for back office terminal import string
+- Reference 4 for shipments string format changed

--- a/config/adapter.yml
+++ b/config/adapter.yml
@@ -1,4 +1,6 @@
 services:
   Invertus\dpdBaltics\Adapter\DPDConfigurationAdapter:
+    class: 'Invertus\dpdBaltics\Adapter\DPDConfigurationAdapter'
 
   Invertus\dpdBaltics\Adapter\ZoneAdapter:
+    class: 'Invertus\dpdBaltics\Adapter\ZoneAdapter'

--- a/config/builder.yml
+++ b/config/builder.yml
@@ -1,13 +1,16 @@
 services:
   Invertus\dpdBaltics\Builder\Template\Admin\InfoBlockBuilder:
+    class: 'Invertus\dpdBaltics\Builder\Template\Admin\InfoBlockBuilder'
     arguments:
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Builder\Template\Admin\WarningBlockBuilder:
+    class: 'Invertus\dpdBaltics\Builder\Template\Admin\WarningBlockBuilder'
     arguments:
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Builder\Template\Admin\ProductBlockBuilder:
+    class: 'Invertus\dpdBaltics\Builder\Template\Admin\ProductBlockBuilder'
     arguments:
       - '@dpdbaltics'
       - '@smarty'
@@ -19,6 +22,7 @@ services:
       - '@Invertus\dpdBaltics\Builder\Template\SearchBoxBuilder'
 
   Invertus\dpdBaltics\Builder\Template\Front\CarrierOptionsBuilder:
+    class: 'Invertus\dpdBaltics\Builder\Template\Front\CarrierOptionsBuilder'
     arguments:
       - '@context'
       - '@Invertus\dpdBaltics\Repository\PriceRuleRepository'
@@ -27,19 +31,23 @@ services:
       - '@Invertus\dpdBaltics\Repository\CarrierRepository'
 
   Invertus\dpdBaltics\Builder\CarrierBuilder:
+    class: 'Invertus\dpdBaltics\Builder\CarrierBuilder'
     arguments:
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Builder\CarrierImageBuilder:
+    class: 'Invertus\dpdBaltics\Builder\CarrierImageBuilder'
     arguments:
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Builder\Template\SearchBoxBuilder:
+    class: 'Invertus\dpdBaltics\Builder\Template\SearchBoxBuilder'
     arguments:
       - '@dpdbaltics'
       - '@smarty'
 
   Invertus\dpdBaltics\Builder\Template\Admin\PhoneInputBuilder:
+    class: 'Invertus\dpdBaltics\Builder\Template\Admin\PhoneInputBuilder'
     arguments:
       - '@dpdbaltics'
       - '@smarty'

--- a/config/command.yml
+++ b/config/command.yml
@@ -1,6 +1,6 @@
 services:
   Invertus\dpdBaltics\ConsoleCommand\UpdateParcelShopsCommand:
-    class : Invertus\dpdBaltics\ConsoleCommand\UpdateParcelShopsCommand
+    class : 'Invertus\dpdBaltics\ConsoleCommand\UpdateParcelShopsCommand'
     arguments:
       - '@Invertus\dpdBaltics\Logger\Logger'
       - '@Invertus\dpdBaltics\Service\Import\API\ParcelShopImport'

--- a/config/config.yml
+++ b/config/config.yml
@@ -53,11 +53,14 @@ services:
     factory: ['Invertus\dpdBaltics\Factory\ContextFactory', 'getShop']
 
   Invertus\dpdBaltics\Config\ApiConfiguration:
+    class: 'Invertus\dpdBaltics\Config\ApiConfiguration'
 
   Invertus\dpdBaltics\Install\Installer:
+    class: 'Invertus\dpdBaltics\Install\Installer'
     arguments:
       - '@dpdbaltics'
       - '@Invertus\dpdBaltics\Factory\TabFactory'
       - '@Invertus\dpdBaltics\Service\Carrier\CreateCarrierService'
 
   Invertus\dpdBaltics\ORM\EntityManager:
+    class: 'Invertus\dpdBaltics\ORM\EntityManager'

--- a/config/converter.yml
+++ b/config/converter.yml
@@ -1,2 +1,3 @@
 services:
   Invertus\dpdBaltics\Converter\FormDataConverter:
+    class: 'Invertus\dpdBaltics\Converter\FormDataConverter'

--- a/config/export.yml
+++ b/config/export.yml
@@ -1,22 +1,27 @@
 services:
   Invertus\dpdBaltics\Service\Export\ExportProvider:
+    class: 'Invertus\dpdBaltics\Service\Export\ExportProvider'
     arguments:
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Service\Export\ZoneExport:
+    class: 'Invertus\dpdBaltics\Service\Export\ZoneExport'
     arguments:
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Service\Export\SettingsExport:
+    class: 'Invertus\dpdBaltics\Service\Export\SettingsExport'
     arguments:
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Service\Export\AddressTemplatesExport:
+    class: 'Invertus\dpdBaltics\Service\Export\AddressTemplatesExport'
     arguments:
       - '@dpdbaltics'
       - '@Invertus\dpdBaltics\Repository\AddressTemplateRepository'
 
   Invertus\dpdBaltics\Service\Export\ProductExport:
+    class: 'Invertus\dpdBaltics\Service\Export\ProductExport'
     arguments:
       - '@dpdbaltics'
       - '@Invertus\dpdBaltics\Repository\ProductRepository'
@@ -25,6 +30,7 @@ services:
       - '@Invertus\dpdBaltics\Repository\ProductAvailabilityRepository'
 
   Invertus\dpdBaltics\Service\Export\PriceRulesExport:
+    class: 'Invertus\dpdBaltics\Service\Export\PriceRulesExport'
     arguments:
       - '@Invertus\dpdBaltics\Repository\PriceRuleRepository'
       - '@dpdbaltics'

--- a/config/factory.yml
+++ b/config/factory.yml
@@ -1,23 +1,29 @@
 services:
   Invertus\dpdBaltics\Factory\ArrayFactory:
+    class: 'Invertus\dpdBaltics\Factory\ArrayFactory'
 
   Invertus\dpdBaltics\Factory\ContextFactory:
+    class: 'Invertus\dpdBaltics\Factory\ContextFactory'
 
   Invertus\dpdBaltics\Factory\TabFactory:
+    class: 'Invertus\dpdBaltics\Factory\TabFactory'
     arguments:
       - '@Invertus\dpdBaltics\Service\TabService'
 
   Invertus\dpdBaltics\Factory\APIParamsFactory:
+    class: 'Invertus\dpdBaltics\Factory\APIParamsFactory'
     arguments:
       - '@dpdbaltics'
       - '@Invertus\dpdBaltics\Config\ApiConfiguration'
 
   Invertus\dpdBaltics\Factory\ShipmentDataFactory:
+    class: 'Invertus\dpdBaltics\Factory\ShipmentDataFactory'
     arguments:
       - '@Invertus\dpdBaltics\Repository\OrderRepository'
       - '@Invertus\dpdBaltics\Repository\ShipmentRepository'
       - '@Invertus\dpdBaltics\Repository\PudoRepository'
 
   Invertus\dpdBaltics\Factory\ShopFactory:
+    class: 'Invertus\dpdBaltics\Factory\ShopFactory'
     arguments:
       - '@Invertus\dpdBaltics\Repository\ParcelShopRepository'

--- a/config/helper.yml
+++ b/config/helper.yml
@@ -1,2 +1,3 @@
 services:
   Invertus\dpdBaltics\Helper\ShipmentHelper:
+    class: 'Invertus\dpdBaltics\Helper\ShipmentHelper'

--- a/config/import.yml
+++ b/config/import.yml
@@ -1,9 +1,11 @@
 services:
   Invertus\dpdBaltics\Service\Import\SettingsImport:
+    class: 'Invertus\dpdBaltics\Service\Import\SettingsImport'
     arguments:
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Service\Import\ZoneImport:
+    class: 'Invertus\dpdBaltics\Service\Import\ZoneImport'
     arguments:
       - '@dpdbaltics'
       - '@Invertus\dpdBaltics\ORM\EntityManager'
@@ -13,16 +15,19 @@ services:
       - '@smarty'
 
   Invertus\dpdBaltics\Service\Import\ImportMainZone:
+    class: 'Invertus\dpdBaltics\Service\Import\ImportMainZone'
     arguments:
       - '@Invertus\dpdBaltics\Service\Import\ImportProvider'
       - '@Invertus\dpdBaltics\Service\Import\ZoneImport'
 
   Invertus\dpdBaltics\Service\Import\ImportProvider:
+    class: 'Invertus\dpdBaltics\Service\Import\ImportProvider'
     arguments:
       - '@dpdbaltics'
       - '@Invertus\dpdBaltics\Adapter\DPDConfigurationAdapter'
 
   Invertus\dpdBaltics\Service\Import\ProductImport:
+    class: 'Invertus\dpdBaltics\Service\Import\ProductImport'
     arguments:
       - '@Invertus\dpdBaltics\Repository\ProductRepository'
       - '@Invertus\dpdBaltics\Repository\ZoneRepository'
@@ -30,6 +35,7 @@ services:
       - '@Invertus\dpdBaltics\Repository\ProductAvailabilityRepository'
 
   Invertus\dpdBaltics\Service\Import\PriceRulesImport:
+    class: 'Invertus\dpdBaltics\Service\Import\PriceRulesImport'
     arguments:
       - '@dpdbaltics'
       - '@Invertus\dpdBaltics\Repository\PriceRuleRepository'
@@ -37,11 +43,13 @@ services:
       - '@Invertus\dpdBaltics\Repository\CarrierRepository'
 
   Invertus\dpdBaltics\Service\Import\AddressTemplatesImport:
+    class: 'Invertus\dpdBaltics\Service\Import\AddressTemplatesImport'
     arguments:
       - '@dpdbaltics'
       - '@Invertus\dpdBaltics\Repository\ShopRepository'
 
   Invertus\dpdBaltics\Service\Import\ZipImport:
+    class: 'Invertus\dpdBaltics\Service\Import\ZipImport'
     arguments:
       - '@dpdbaltics'
       - '@smarty'

--- a/config/onBoard.yml
+++ b/config/onBoard.yml
@@ -152,7 +152,7 @@ services:
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts3:
-    clasS: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts3'
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts3'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts4:

--- a/config/onBoard.yml
+++ b/config/onBoard.yml
@@ -1,10 +1,12 @@
 services:
   Invertus\dpdBaltics\OnBoard\Builder\OnBoardBlockBuilder:
+    class: 'Invertus\dpdBaltics\OnBoard\Builder\OnBoardBlockBuilder'
     arguments:
       - '@dpdbaltics'
       - '@smarty'
 
   Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep:
+    class: 'Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep'
     abstract: true
     arguments:
       - '@dpdbaltics'
@@ -12,6 +14,7 @@ services:
       - '@Invertus\dpdBaltics\OnBoard\Service\OnBoardStepDataService'
 
   Invertus\dpdBaltics\OnBoard\Provider\OnBoardStepStrategyProvider:
+    class: 'Invertus\dpdBaltics\OnBoard\Provider\OnBoardStepStrategyProvider'
     arguments:
       - '@Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepImport1'
       - '@Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepImport2'
@@ -51,12 +54,14 @@ services:
       - '@Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZonesAfterImport'
 
   Invertus\dpdBaltics\OnBoard\Service\OnBoardStepActionService:
+    class: 'Invertus\dpdBaltics\OnBoard\Service\OnBoardStepActionService'
     arguments:
       - '@dpdBaltics'
       - '@controller'
       - '@cookie'
 
   Invertus\dpdBaltics\OnBoard\Service\OnBoardStepDataService:
+    class: 'Invertus\dpdBaltics\OnBoard\Service\OnBoardStepDataService'
     arguments:
       - '@dpdBaltics'
       - '@cookie'
@@ -65,111 +70,147 @@ services:
       - '@Invertus\dpdBaltics\Repository\ProductRepository'
 
   Invertus\dpdBaltics\OnBoard\Service\OnBoardService:
+    class: 'Invertus\dpdBaltics\OnBoard\Service\OnBoardService'
     arguments:
       - '@Invertus\dpdBaltics\OnBoard\Provider\OnBoardStepStrategyProvider'
       - '@Invertus\dpdBaltics\OnBoard\Builder\OnBoardBlockBuilder'
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepImport1:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepImport1'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepImport2:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepImport2'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepImportFinish:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepImportFinish'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepMain1:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepMain1'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepMain2:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepMain2'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepMain3:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepMain3'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualConfigFinish:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualConfigFinish'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules0:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules0'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules1:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules1'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules2:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules2'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules3:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules3'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules4:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules4'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules5:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules5'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules6:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules6'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules7:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules7'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules8:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualPriceRules8'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts0:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts0'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts1:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts1'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts2:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts2'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts3:
+    clasS: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts3'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts4:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts4'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts5:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts5'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts5Shop:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts5Shop'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts6:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts6'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts7:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts7'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts8:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts8'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts9:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualProducts9'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZones0:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZones0'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZones1:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZones1'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZones2:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZones2'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZones3:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZones3'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZones4:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZones4'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZones5:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZones5'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZones6:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZones6'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep
 
   Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZonesAfterImport:
+    class: 'Invertus\dpdBaltics\OnBoard\OnBoardSteps\StepManualZonesAfterImport'
     parent: Invertus\dpdBaltics\OnBoard\AbstractOnBoardStep

--- a/config/presenter.yml
+++ b/config/presenter.yml
@@ -1,10 +1,12 @@
 services:
   Invertus\dpdBaltics\Presenter\DeliveryTimePresenter:
+    class: 'Invertus\dpdBaltics\Presenter\DeliveryTimePresenter'
     arguments:
       - '@context'
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Presenter\SameDayDeliveryMessagePresenter:
+    class: 'Invertus\dpdBaltics\Presenter\SameDayDeliveryMessagePresenter'
     arguments:
       - '@context'
       - '@dpdbaltics'

--- a/config/provider.yml
+++ b/config/provider.yml
@@ -1,13 +1,16 @@
 services:
   Invertus\dpdBaltics\Provider\ImportExportOptionsProvider:
+    class: 'Invertus\dpdBaltics\Provider\ImportExportOptionsProvider'
     arguments:
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Provider\ImportExportURLProvider:
+    class: 'Invertus\dpdBaltics\Provider\ImportExportURLProvider'
     arguments:
       - '@context'
 
   Invertus\dpdBaltics\Provider\ProductShippingCostProvider:
+    class: 'Invertus\dpdBaltics\Provider\ProductShippingCostProvider'
     arguments:
       - '@dpdbaltics'
       -  '@Invertus\dpdBaltics\Repository\ProductRepository'
@@ -16,10 +19,12 @@ services:
       -  '@currency'
 
   Invertus\dpdBaltics\Provider\ZoneRangeProvider:
+    class: 'Invertus\dpdBaltics\Provider\ZoneRangeProvider'
     arguments:
       - '@language'
 
   Invertus\dpdBaltics\Provider\ProductAvailabilityProvider:
+    class: 'Invertus\dpdBaltics\Provider\ProductAvailabilityProvider'
     arguments:
       - '@language'
       - '@Invertus\dpdBaltics\Repository\ProductAvailabilityRepository'

--- a/config/repository.yml
+++ b/config/repository.yml
@@ -1,50 +1,75 @@
 services:
   Invertus\dpdBaltics\Repository\CarrierRepository:
+    class: 'Invertus\dpdBaltics\Repository\CarrierRepository'
 
   Invertus\dpdBaltics\Repository\DPDZoneRepository:
+    class: 'Invertus\dpdBaltics\Repository\DPDZoneRepository'
 
   Invertus\dpdBaltics\Repository\OrderRepository:
+    class: 'Invertus\dpdBaltics\Repository\OrderRepository'
 
   Invertus\dpdBaltics\Repository\ProductRepository:
+    class: 'Invertus\dpdBaltics\Repository\ProductRepository'
 
   Invertus\dpdBaltics\Repository\ProductZoneRepository:
+    class: 'Invertus\dpdBaltics\Repository\ProductZoneRepository'
 
   Invertus\dpdBaltics\Repository\ProductShopRepository:
+    class: 'Invertus\dpdBaltics\Repository\ProductShopRepository'
 
   Invertus\dpdBaltics\Repository\PriceRuleRepository:
+    class: 'Invertus\dpdBaltics\Repository\PriceRuleRepository'
 
   Invertus\dpdBaltics\Repository\PhonePrefixRepository:
+    class: 'Invertus\dpdBaltics\Repository\PhonePrefixRepository'
 
   Invertus\dpdBaltics\Repository\ZoneRepository:
+    class: 'Invertus\dpdBaltics\Repository\ZoneRepository'
 
   Invertus\dpdBaltics\Repository\ZoneRangeRepository:
+    class: 'Invertus\dpdBaltics\Repository\ZoneRangeRepository'
 
   Invertus\dpdBaltics\Repository\PaymentRepository:
+    class: 'Invertus\dpdBaltics\Repository\PaymentRepository'
 
   Invertus\dpdBaltics\Repository\ShipmentRepository:
+    class: 'Invertus\dpdBaltics\Repository\ShipmentRepository'
 
   Invertus\dpdBaltics\Repository\ReceiverAddressRepository:
+    class: 'Invertus\dpdBaltics\Repository\ReceiverAddressRepository'
 
   Invertus\dpdBaltics\Repository\PhoneRepository:
+    class: 'Invertus\dpdBaltics\Repository\PhoneRepository'
 
   Invertus\dpdBaltics\Repository\CodPaymentRepository:
+    class: 'Invertus\dpdBaltics\Repository\CodPaymentRepository'
 
   Invertus\dpdBaltics\Repository\PudoRepository:
+    class: 'Invertus\dpdBaltics\Repository\PudoRepository'
 
   Invertus\dpdBaltics\Repository\LogsRepository:
+    class: 'Invertus\dpdBaltics\Repository\LogsRepository'
 
   Invertus\dpdBaltics\Repository\AddressRepository:
+    class: 'Invertus\dpdBaltics\Repository\AddressRepository'
 
   Invertus\dpdBaltics\Repository\CollectionRequestRepository:
+    class: 'Invertus\dpdBaltics\Repository\CollectionRequestRepository'
 
   Invertus\dpdBaltics\Repository\CourierRequestRepository:
+    class: 'Invertus\dpdBaltics\Repository\CourierRequestRepository'
 
   Invertus\dpdBaltics\Repository\AddressTemplateRepository:
+    class: 'Invertus\dpdBaltics\Repository\AddressTemplateRepository'
 
   Invertus\dpdBaltics\Repository\ShopRepository:
+    class: 'Invertus\dpdBaltics\Repository\ShopRepository'
 
   Invertus\dpdBaltics\Repository\ParcelShopRepository:
+    class: 'Invertus\dpdBaltics\Repository\ParcelShopRepository'
 
   Invertus\dpdBaltics\Repository\ProductAvailabilityRepository:
+    class: 'Invertus\dpdBaltics\Repository\ProductAvailabilityRepository'
 
   Invertus\dpdBaltics\Repository\OrderDeliveryTimeRepository:
+    class: 'Invertus\dpdBaltics\Repository\OrderDeliveryTimeRepository'

--- a/config/requestFactory.yml
+++ b/config/requestFactory.yml
@@ -1,34 +1,39 @@
 services:
   Invertus\dpdBalticsApi\Factory\APIRequest\ClosingManifestFactory:
+    class: 'Invertus\dpdBalticsApi\Factory\APIRequest\ClosingManifestFactory'
     arguments:
       - '@Invertus\dpdBaltics\Logger\Logger'
       - '@Invertus\dpdBaltics\Factory\APIParamsFactory'
 
   Invertus\dpdBalticsApi\Factory\APIRequest\CollectionRequestFactory:
+    class: 'Invertus\dpdBalticsApi\Factory\APIRequest\CollectionRequestFactory'
     arguments:
       - '@Invertus\dpdBaltics\Logger\Logger'
       - '@Invertus\dpdBaltics\Factory\APIParamsFactory'
 
 
   Invertus\dpdBalticsApi\Factory\APIRequest\CourierRequestFactory:
+    class: 'Invertus\dpdBalticsApi\Factory\APIRequest\CourierRequestFactory'
     arguments:
       - '@Invertus\dpdBaltics\Logger\Logger'
       - '@Invertus\dpdBaltics\Factory\APIParamsFactory'
 
 
   Invertus\dpdBalticsApi\Factory\APIRequest\ParcelPrintFactory:
+    class: 'Invertus\dpdBalticsApi\Factory\APIRequest\ParcelPrintFactory'
     arguments:
       - '@Invertus\dpdBaltics\Logger\Logger'
       - '@Invertus\dpdBaltics\Factory\APIParamsFactory'
 
 
   Invertus\dpdBalticsApi\Factory\APIRequest\ParcelShopSearchFactory:
+    class: 'Invertus\dpdBalticsApi\Factory\APIRequest\ParcelShopSearchFactory'
     arguments:
       - '@Invertus\dpdBaltics\Logger\Logger'
       - '@Invertus\dpdBaltics\Factory\APIParamsFactory'
 
-
   Invertus\dpdBalticsApi\Factory\APIRequest\ShipmentCreationFactory:
+    class: 'Invertus\dpdBalticsApi\Factory\APIRequest\ShipmentCreationFactory'
     arguments:
       - '@Invertus\dpdBaltics\Logger\Logger'
       - '@Invertus\dpdBaltics\Factory\APIParamsFactory'

--- a/config/service.yml
+++ b/config/service.yml
@@ -1,11 +1,13 @@
 services:
   Invertus\dpdBaltics\Service\Carrier\CreateCarrierService:
+    class: 'Invertus\dpdBaltics\Service\Carrier\CreateCarrierService'
     arguments:
       - '@language'
       - '@Invertus\dpdBaltics\Builder\CarrierBuilder'
       - '@Invertus\dpdBaltics\Builder\CarrierImageBuilder'
 
   Invertus\dpdBaltics\Service\CarrierPhoneService:
+    class: 'Invertus\dpdBaltics\Service\CarrierPhoneService'
     arguments:
       - '@dpdbaltics'
       - '@context'
@@ -14,35 +16,43 @@ services:
       - '@Invertus\dpdBaltics\Repository\OrderRepository'
 
   Invertus\dpdBaltics\Service\Carrier\UpdateCarrierService:
+    class: 'Invertus\dpdBaltics\Service\Carrier\UpdateCarrierService'
     arguments:
       - '@Invertus\dpdBaltics\Service\LanguageService'
       - '@Invertus\dpdBaltics\Validate\Carrier\CarrierUpdateValidate'
 
   Invertus\dpdBaltics\Service\DPDFlashMessageService:
+    class: 'Invertus\dpdBaltics\Service\DPDFlashMessageService'
     arguments:
       - '@context'
 
   Invertus\dpdBaltics\Service\LanguageService:
+    class: 'Invertus\dpdBaltics\Service\LanguageService'
 
   Invertus\dpdBaltics\Service\Product\ProductService:
+    class: 'Invertus\dpdBaltics\Service\Product\ProductService'
     arguments:
       - '@Invertus\dpdBaltics\Repository\ProductRepository'
       - '@Invertus\dpdBaltics\Service\Carrier\CreateCarrierService'
 
   Invertus\dpdBaltics\Service\Product\ProductAvailabilityService:
+    class: 'Invertus\dpdBaltics\Service\Product\ProductAvailabilityService'
     arguments:
       - '@Invertus\dpdBaltics\Repository\ProductAvailabilityRepository'
       - '@Invertus\dpdBaltics\Repository\ProductRepository'
 
   Invertus\dpdBaltics\Service\Product\UpdateProductZoneService:
+    class: 'Invertus\dpdBaltics\Service\Product\UpdateProductZoneService'
     arguments:
       - '@Invertus\dpdBaltics\Repository\ProductZoneRepository'
 
   Invertus\dpdBaltics\Service\Product\UpdateProductShopService:
+    class: 'Invertus\dpdBaltics\Service\Product\UpdateProductShopService'
     arguments:
       - '@Invertus\dpdBaltics\Repository\ProductShopRepository'
 
   Invertus\dpdBaltics\Service\PriceRuleService:
+    class: 'Invertus\dpdBaltics\Service\PriceRuleService'
     arguments:
       - '@dpdbaltics'
       - '@Invertus\dpdBaltics\Repository\PriceRuleRepository'
@@ -56,10 +66,12 @@ services:
       - '@shop'
 
   Invertus\dpdBaltics\Service\TabService:
+    class: 'Invertus\dpdBaltics\Service\TabService'
     arguments:
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Service\Zone\DeleteZoneService:
+    class: 'Invertus\dpdBaltics\Service\Zone\DeleteZoneService'
     arguments:
       - '@dpdbaltics'
       - '@Invertus\dpdBaltics\Repository\CarrierRepository'
@@ -67,8 +79,11 @@ services:
       - '@Invertus\dpdBaltics\Factory\ArrayFactory'
 
   Invertus\dpdBaltics\Service\Zone\UpdateZoneService:
+    class: 'Invertus\dpdBaltics\Service\Zone\UpdateZoneService'
 
   Invertus\dpdBaltics\Service\ShipmentService:
+    class: 'Invertus\dpdBaltics\Service\ShipmentService'
+    arguments:
     - '@dpdbaltics'
     - '@language'
     - '@Invertus\dpdBaltics\Repository\ShipmentRepository'
@@ -83,11 +98,14 @@ services:
 
 
   Invertus\dpdBaltics\Service\Label\LabelPrintingService:
+    class: 'Invertus\dpdBaltics\Service\Label\LabelPrintingService'
+    arguments:
     - '@dpdbaltics'
     - '@Invertus\dpdBaltics\Service\API\ShipmentApiService'
     - '@Invertus\dpdBaltics\Service\Exception\ExceptionService'
 
   Invertus\dpdBaltics\Service\Address\ReceiverAddressService:
+    class: 'Invertus\dpdBaltics\Service\Address\ReceiverAddressService'
     arguments:
       - '@dpdbaltics'
       - '@smarty'
@@ -99,19 +117,23 @@ services:
       - '@Invertus\dpdBaltics\Service\OrderService'
 
   Invertus\dpdBaltics\Service\Address\AddressTemplateService:
+    class: 'Invertus\dpdBaltics\Service\Address\AddressTemplateService'
     arguments:
       - '@Invertus\dpdBaltics\Repository\ShopRepository'
 
   Invertus\dpdBaltics\Service\Label\LabelPositionService:
+    class: 'Invertus\dpdBaltics\Service\Label\LabelPositionService'
     arguments:
       - '@dpdbaltics'
       - '@Smarty'
 
   Invertus\dpdBaltics\Service\OrderService:
+    class: 'Invertus\dpdBaltics\Service\OrderService'
     arguments:
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Service\Payment\PaymentService:
+    class: 'Invertus\dpdBaltics\Service\Payment\PaymentService'
     arguments:
       - '@Invertus\dpdBaltics\Repository\CodPaymentRepository'
       - '@Invertus\dpdBaltics\Repository\PudoRepository'
@@ -121,20 +143,24 @@ services:
       - '@shop'
 
   Invertus\dpdBaltics\Service\API\ShipmentApiService:
+    class: 'Invertus\dpdBaltics\Service\API\ShipmentApiService'
     arguments:
       - '@Invertus\dpdBalticsApi\Factory\APIRequest\ShipmentCreationFactory'
       - '@Invertus\dpdBaltics\Repository\CodPaymentRepository'
 
   Invertus\dpdBaltics\Service\API\LabelApiService:
+    class: 'Invertus\dpdBaltics\Service\API\LabelApiService'
     arguments:
       - '@Invertus\dpdBaltics\Util\FileDownload'
       - '@Invertus\dpdBalticsApi\Factory\APIRequest\ParcelPrintFactory'
 
   Invertus\dpdBaltics\Service\API\ParcelShopSearchApiService:
+    class: 'Invertus\dpdBaltics\Service\API\ParcelShopSearchApiService'
     arguments:
       - '@Invertus\dpdBalticsApi\Factory\APIRequest\ParcelShopSearchFactory'
 
   Invertus\dpdBaltics\Service\PudoService:
+    class: 'Invertus\dpdBaltics\Service\PudoService'
     arguments:
       - '@Invertus\dpdBaltics\Repository\PudoRepository'
       - '@smarty'
@@ -146,49 +172,60 @@ services:
       - '@Invertus\dpdBaltics\Factory\ShopFactory'
 
   Invertus\dpdBaltics\Service\GoogleApiService:
+    class: 'Invertus\dpdBaltics\Service\GoogleApiService'
     arguments:
       - '@language'
       - '@shop'
 
   Invertus\dpdBaltics\Logger\Logger:
+    class: 'Invertus\dpdBaltics\Logger\Logger'
     arguments:
       - '@Invertus\dpdBaltics\Service\LogsService'
 
   Invertus\dpdBaltics\Service\LogsService:
+    class: 'Invertus\dpdBaltics\Service\LogsService'
     arguments:
       - '@Invertus\dpdBaltics\Repository\LogsRepository'
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Service\API\CollectionRequestService:
+    class: 'Invertus\dpdBaltics\Service\API\CollectionRequestService'
     arguments:
       - '@Invertus\dpdBalticsApi\Factory\APIRequest\CollectionRequestFactory'
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Service\API\CourierRequestService:
+    class: 'Invertus\dpdBaltics\Service\API\CourierRequestService'
     arguments:
       - '@Invertus\dpdBalticsApi\Factory\APIRequest\CourierRequestFactory'
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Service\Parcel\ParcelUpdateService:
+    class: 'Invertus\dpdBaltics\Service\Parcel\ParcelUpdateService'
     arguments:
       - '@Invertus\dpdBaltics\Repository\ParcelShopRepository'
 
   Invertus\dpdBaltics\Service\Parcel\ParcelShopService:
+    class: 'Invertus\dpdBaltics\Service\Parcel\ParcelShopService'
     arguments:
       - '@Invertus\dpdBaltics\Repository\ParcelShopRepository'
       - '@Invertus\dpdBaltics\Factory\ShopFactory'
 
   Invertus\dpdBaltics\Service\OrderDeliveryTimeService:
+    class: 'Invertus\dpdBaltics\Service\OrderDeliveryTimeService'
     arguments:
       - '@Invertus\dpdBaltics\Repository\OrderDeliveryTimeRepository'
 
   Invertus\dpdBaltics\Service\TrackingService:
+    class: 'Invertus\dpdBaltics\Service\TrackingService'
 
   Invertus\dpdBaltics\Service\Exception\ExceptionService:
+    class: 'Invertus\dpdBaltics\Service\Exception\ExceptionService'
     arguments:
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Service\Import\API\ParcelShopImport:
+    class: 'Invertus\dpdBaltics\Service\Import\API\ParcelShopImport'
     arguments:
       - '@Invertus\dpdBaltics\Service\API\ParcelShopSearchApiService'
       - '@Invertus\dpdBaltics\Service\Parcel\ParcelUpdateService'

--- a/config/templateRender.yml
+++ b/config/templateRender.yml
@@ -1,5 +1,6 @@
 services:
   Invertus\dpdBaltics\Templating\InfoBlockRender:
+    class: 'Invertus\dpdBaltics\Templating\InfoBlockRender'
     arguments:
       - '@Invertus\dpdBaltics\Builder\Template\Admin\InfoBlockBuilder'
       - '@smarty'

--- a/config/util.yml
+++ b/config/util.yml
@@ -1,4 +1,5 @@
 services:
   Invertus\dpdBaltics\Util\FileDownload:
+    class: 'Invertus\dpdBaltics\Util\FileDownload'
     arguments:
       - '@dpdbaltics'

--- a/config/validator.yml
+++ b/config/validator.yml
@@ -1,27 +1,33 @@
 services:
   Invertus\dpdBaltics\Validate\Zone\ZoneRangeValidate:
+    class: 'Invertus\dpdBaltics\Validate\Zone\ZoneRangeValidate'
     arguments:
       - '@dpdbaltics'
       - '@language'
 
   Invertus\dpdBaltics\Validate\Zone\ZoneDeleteValidate:
+    class: 'Invertus\dpdBaltics\Validate\Zone\ZoneDeleteValidate'
     arguments:
       - '@dpdbaltics'
       - '@Invertus\dpdBaltics\ORM\EntityManager'
 
   Invertus\dpdBaltics\Validate\Carrier\CarrierUpdateValidate:
+    class: 'Invertus\dpdBaltics\Validate\Carrier\CarrierUpdateValidate'
     arguments:
       - '@dpdbaltics'
 
   Invertus\dpdBaltics\Validate\Carrier\PudoValidate:
+    class: 'Invertus\dpdBaltics\Validate\Carrier\PudoValidate'
     arguments:
       - '@dpdbaltics'
       - '@Invertus\dpdBaltics\Repository\PudoRepository'
       - '@Invertus\dpdBaltics\Repository\ProductRepository'
 
   Invertus\dpdBaltics\Validate\CourierRequest\CourierRequestValidator:
+    class: 'Invertus\dpdBaltics\Validate\CourierRequest\CourierRequestValidator'
 
   Invertus\dpdBaltics\Validate\Weight\CartWeightValidator:
+    class: 'Invertus\dpdBaltics\Validate\Weight\CartWeightValidator'
 
   Invertus\dpdBaltics\Validate\ShipmentData\ShipmentDataValidator:
-      class: Invertus\dpdBaltics\Validate\ShipmentData\ShipmentDataValidator
+    class: 'Invertus\dpdBaltics\Validate\ShipmentData\ShipmentDataValidator'

--- a/controllers/admin/AdminDPDAjaxOnBoardController.php
+++ b/controllers/admin/AdminDPDAjaxOnBoardController.php
@@ -17,6 +17,8 @@ use Invertus\dpdBaltics\OnBoard\Provider\OnBoardStepStrategyProvider;
 use Invertus\dpdBaltics\OnBoard\Service\OnBoardService;
 use Invertus\dpdBaltics\OnBoard\Service\OnBoardStepActionService;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDAjaxOnBoardController extends AbstractAdminController
 {
     /**

--- a/controllers/admin/AdminDPDBalticsAddressTemplateController.php
+++ b/controllers/admin/AdminDPDBalticsAddressTemplateController.php
@@ -10,6 +10,8 @@ use Invertus\dpdBaltics\Repository\ShopRepository;
 use Invertus\dpdBaltics\Service\Address\AddressTemplateService;
 use Invertus\dpdBaltics\Util\CountryUtility;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsAddressTemplateController extends AbstractAdminController
 {
 

--- a/controllers/admin/AdminDPDBalticsAjaxController.php
+++ b/controllers/admin/AdminDPDBalticsAjaxController.php
@@ -19,6 +19,8 @@ use Invertus\dpdBaltics\Service\Parcel\ParcelUpdateService;
 use Invertus\dpdBaltics\Service\PudoService;
 use Invertus\dpdBalticsApi\Api\DTO\Response\ParcelShopSearchResponse;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsAjaxController extends AbstractAdminController
 {
     public function ajaxProcessImportZones()

--- a/controllers/admin/AdminDPDBalticsAjaxShipmentsController.php
+++ b/controllers/admin/AdminDPDBalticsAjaxShipmentsController.php
@@ -30,6 +30,8 @@ use Invertus\dpdBalticsApi\Api\DTO\Response\ParcelShopSearchResponse;
 use Invertus\dpdBalticsApi\Api\DTO\Response\ShipmentCreationResponse;
 use Invertus\dpdBalticsApi\Exception\DPDBalticsAPIException;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsAjaxShipmentsController extends AbstractAdminController
 {
     protected $ajaxActions = ['save', 'save_and_print', 'updateAddressBlock', 'getProductPriceByID', 'print'];

--- a/controllers/admin/AdminDPDBalticsCollectionRequestController.php
+++ b/controllers/admin/AdminDPDBalticsCollectionRequestController.php
@@ -12,6 +12,8 @@ use Invertus\dpdBaltics\Service\API\CollectionRequestService;
 use Invertus\dpdBaltics\Service\Exception\ExceptionService;
 use Invertus\dpdBalticsApi\Exception\DPDBalticsAPIException;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsCollectionRequestController extends AbstractAdminController
 {
     public function __construct()

--- a/controllers/admin/AdminDPDBalticsCourierRequestController.php
+++ b/controllers/admin/AdminDPDBalticsCourierRequestController.php
@@ -14,6 +14,8 @@ use Invertus\dpdBaltics\Util\TimeZoneUtility;
 use Invertus\dpdBaltics\Validate\CourierRequest\CourierRequestValidator;
 use Invertus\dpdBalticsApi\Exception\DPDBalticsAPIException;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsCourierRequestController extends AbstractAdminController
 {
     public function __construct()

--- a/controllers/admin/AdminDPDBalticsImportExportController.php
+++ b/controllers/admin/AdminDPDBalticsImportExportController.php
@@ -18,6 +18,8 @@ use Invertus\dpdBaltics\Service\Import\ZipImport;
 use Invertus\dpdBaltics\Service\Import\ZoneImport;
 use Invertus\dpdBaltics\Templating\InfoBlockRender;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsImportExportController extends AbstractAdminController
 {
     public function init()

--- a/controllers/admin/AdminDPDBalticsLogsController.php
+++ b/controllers/admin/AdminDPDBalticsLogsController.php
@@ -3,6 +3,8 @@
 
 use Invertus\dpdBaltics\Controller\AbstractAdminController;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsLogsController extends AbstractAdminController
 {
     public function __construct()

--- a/controllers/admin/AdminDPDBalticsModuleController.php
+++ b/controllers/admin/AdminDPDBalticsModuleController.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsModuleController extends ModuleAdminController
 {
     public function postProcess()

--- a/controllers/admin/AdminDPDBalticsOrderReturnController.php
+++ b/controllers/admin/AdminDPDBalticsOrderReturnController.php
@@ -3,6 +3,8 @@
 
 use Invertus\dpdBaltics\Controller\AbstractAdminController;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsOrderReturnController extends AbstractAdminController
 {
     public function __construct()

--- a/controllers/admin/AdminDPDBalticsPriceRulesController.php
+++ b/controllers/admin/AdminDPDBalticsPriceRulesController.php
@@ -18,6 +18,8 @@ use Invertus\dpdBaltics\Repository\ShopRepository;
 use Invertus\dpdBaltics\Service\DPDFlashMessageService;
 use Invertus\dpdBaltics\Service\PriceRuleService;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsPriceRulesController extends AbstractAdminController
 {
     /** @var  DPDPriceRule */

--- a/controllers/admin/AdminDPDBalticsProductsAvailabilityController.php
+++ b/controllers/admin/AdminDPDBalticsProductsAvailabilityController.php
@@ -1,11 +1,4 @@
 <?php
-
-use Invertus\dpdBaltics\Config\Config;
-use Invertus\dpdBaltics\Controller\AbstractAdminController;
-use Invertus\dpdBaltics\Exception\ProductAvailabilityUpdateException;
-use Invertus\dpdBaltics\Provider\ProductAvailabilityProvider;
-use Invertus\dpdBaltics\Service\Product\ProductAvailabilityService;
-
 /**
  * NOTICE OF LICENSE
  *
@@ -16,6 +9,14 @@ use Invertus\dpdBaltics\Service\Product\ProductAvailabilityService;
  *
  *  International Registered Trademark & Property of INVERTUS, UAB
  */
+use Invertus\dpdBaltics\Config\Config;
+use Invertus\dpdBaltics\Controller\AbstractAdminController;
+use Invertus\dpdBaltics\Exception\ProductAvailabilityUpdateException;
+use Invertus\dpdBaltics\Provider\ProductAvailabilityProvider;
+use Invertus\dpdBaltics\Service\Product\ProductAvailabilityService;
+
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsProductsAvailabilityController extends AbstractAdminController
 {
     public function __construct()

--- a/controllers/admin/AdminDPDBalticsProductsController.php
+++ b/controllers/admin/AdminDPDBalticsProductsController.php
@@ -1,13 +1,4 @@
 <?php
-
-use Invertus\dpdBaltics\Builder\Template\Admin\ProductBlockBuilder;
-use Invertus\dpdBaltics\Controller\AbstractAdminController;
-use Invertus\dpdBaltics\Exception\ProductUpdateException;
-use Invertus\dpdBaltics\Service\Carrier\UpdateCarrierService;
-use Invertus\dpdBaltics\Service\Product\ProductService;
-use Invertus\dpdBaltics\Service\Product\UpdateProductShopService;
-use Invertus\dpdBaltics\Service\Product\UpdateProductZoneService;
-
 /**
  * NOTICE OF LICENSE
  *
@@ -18,6 +9,16 @@ use Invertus\dpdBaltics\Service\Product\UpdateProductZoneService;
  *
  *  International Registered Trademark & Property of INVERTUS, UAB
  */
+use Invertus\dpdBaltics\Builder\Template\Admin\ProductBlockBuilder;
+use Invertus\dpdBaltics\Controller\AbstractAdminController;
+use Invertus\dpdBaltics\Exception\ProductUpdateException;
+use Invertus\dpdBaltics\Service\Carrier\UpdateCarrierService;
+use Invertus\dpdBaltics\Service\Product\ProductService;
+use Invertus\dpdBaltics\Service\Product\UpdateProductShopService;
+use Invertus\dpdBaltics\Service\Product\UpdateProductZoneService;
+
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsProductsController extends AbstractAdminController
 {
     public function __construct()

--- a/controllers/admin/AdminDPDBalticsPudoAjaxController.php
+++ b/controllers/admin/AdminDPDBalticsPudoAjaxController.php
@@ -7,6 +7,8 @@ use Invertus\dpdBaltics\Repository\ProductRepository;
 use Invertus\dpdBaltics\Repository\PudoRepository;
 use Invertus\dpdBaltics\Service\OrderService;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsPudoAjaxController extends AbstractAdminController
 {
     public function postProcess()

--- a/controllers/admin/AdminDPDBalticsRequestSupportController.php
+++ b/controllers/admin/AdminDPDBalticsRequestSupportController.php
@@ -14,6 +14,8 @@ use Invertus\dpdBaltics\Config\Config;
 use Invertus\dpdBaltics\Controller\AbstractAdminController;
 use Invertus\dpdBaltics\Service\LogsService;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsRequestSupportController extends AbstractAdminController
 {
     public function postProcess()

--- a/controllers/admin/AdminDPDBalticsSettingsController.php
+++ b/controllers/admin/AdminDPDBalticsSettingsController.php
@@ -11,6 +11,8 @@ use Invertus\dpdBaltics\Service\LogsService;
 use Invertus\dpdBaltics\Service\Product\ProductService;
 use Invertus\dpdBaltics\Templating\InfoBlockRender;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsSettingsController extends AbstractAdminController
 {
     public function init()

--- a/controllers/admin/AdminDPDBalticsShipmentController.php
+++ b/controllers/admin/AdminDPDBalticsShipmentController.php
@@ -3,6 +3,8 @@
 
 use Invertus\dpdBaltics\Controller\AbstractAdminController;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsShipmentController extends AbstractAdminController
 {
     public function __construct()

--- a/controllers/admin/AdminDPDBalticsShipmentSettingsController.php
+++ b/controllers/admin/AdminDPDBalticsShipmentSettingsController.php
@@ -10,6 +10,8 @@ use Invertus\dpdBaltics\Service\Label\LabelPositionService;
 use Invertus\dpdBaltics\Templating\InfoBlockRender;
 use Invertus\dpdBaltics\Util\CountryUtility;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsShipmentSettingsController extends AbstractAdminController
 {
     public function __construct()

--- a/controllers/admin/AdminDPDBalticsZonesController.php
+++ b/controllers/admin/AdminDPDBalticsZonesController.php
@@ -24,6 +24,8 @@ use Invertus\dpdBaltics\Service\Zone\DeleteZoneService;
 use Invertus\dpdBaltics\Service\Zone\UpdateZoneService;
 use Invertus\dpdBaltics\Validate\Zone\ZoneRangeValidate;
 
+require_once dirname(__DIR__).'/../vendor/autoload.php';
+
 class AdminDPDBalticsZonesController extends AbstractAdminController
 {
     /**


### PR DESCRIPTION
This bug affects ps 1701/2/3 versions 

If service declared like this:
Invertus\dpdBaltics\Templating\InfoBlockRender:
Throws syntax error
If service defined ike this:
Invertus\dpdBaltics\Validate\Zone\ZoneDeleteValidate:
    arguments:
      - '@dpdbaltics'
      - '@Invertus\dpdBaltics\ORM\EntityManager'
Throws an error which says class is not present