### PR TITLE
Return label fix on first donwload and bulk action

### DIFF
--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -1107,6 +1107,10 @@ class DPDBaltics extends CarrierModule
         try {
             /** @var ParcelPrintResponse $parcelPrintResponse */
             if ($isAutomated) {
+                if (!$shipment->return_pl_number) {
+                    $shipmentService = $this->getModuleContainer('invertus.dpdbaltics.service.shipment_service');
+                    $shipmentService->createReturnServiceShipment(Config::RETURN_TEMPLATE_DEFAUTL_ID, $shipment->id_order);
+                }
                 $parcelPrintResponse = $this->printConcatedLabels($shipment, $format, $position);
             } else {
                 $parcelPrintResponse = $labelApiService->printLabel($shipment->pl_number, $format, $position, false);
@@ -1404,7 +1408,6 @@ class DPDBaltics extends CarrierModule
         $plNumbers = [$shipment->pl_number, $shipment->return_pl_number];
         /** @var LabelApiService $labelApiService */
         $labelApiService = $this->getModuleContainer('invertus.dpdbaltics.service.api.label_api_service');
-
         return $labelApiService->printLabel(implode('|', $plNumbers), $format, $position, false);
 
     }

--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -1109,7 +1109,7 @@ class DPDBaltics extends CarrierModule
             if ($isAutomated) {
                 if (!$shipment->return_pl_number) {
                     $shipmentService = $this->getModuleContainer('invertus.dpdbaltics.service.shipment_service');
-                    $shipmentService->createReturnServiceShipment(Config::RETURN_TEMPLATE_DEFAUTL_ID, $shipment->id_order);
+                    $shipmentService->createReturnServiceShipment(Config::RETURN_TEMPLATE_DEFAULT_ID, $shipment->id_order);
                 }
                 $parcelPrintResponse = $this->printConcatedLabels($shipment, $format, $position);
             } else {

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -126,7 +126,7 @@ class Config
     const API_COLLECTION_REQUEST_ERROR_STATUS = '402 Error:';
     const API_COURIER_REQUEST_ERROR_STATUS = '402 Error:';
     const API_RESPONSE_ERROR_STATUS = 'err';
-    const RETURN_TEMPLATE_DEFAUTL_ID = 1;
+    const RETURN_TEMPLATE_DEFAULT_ID = 1;
 
     const DEFAULT_LABEL_TYPE = 'pdf';
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -126,6 +126,7 @@ class Config
     const API_COLLECTION_REQUEST_ERROR_STATUS = '402 Error:';
     const API_COURIER_REQUEST_ERROR_STATUS = '402 Error:';
     const API_RESPONSE_ERROR_STATUS = 'err';
+    const RETURN_TEMPLATE_DEFAUTL_ID = 1;
 
     const DEFAULT_LABEL_TYPE = 'pdf';
 


### PR DESCRIPTION
After QA there was an error, that on just created order on automatization setting on return label is not printed. After analysis, it became clear that return shipment, in general, is not created so we need to create it, since I can't pass here any template ID I see the option just send default return parcel ID.