### PR TITLE
Dgs 213/zone range

### DIFF
--- a/views/js/admin/models/DPDZoneRangesData.js
+++ b/views/js/admin/models/DPDZoneRangesData.js
@@ -48,7 +48,7 @@ DPDZoneRangesData.prototype.addZoneRange = function (zoneRange)
  * @param {integer|string} zoneRangeId
  * @param {object} valueObject Object containing updated values
  */
-DPDZoneRangesData.prototype.updateZoneRangeupdateZoneRange = function (zoneRangeId, valueObject) {
+DPDZoneRangesData.prototype.updateZoneRange = function (zoneRangeId, valueObject) {
     var self = this;
 
     this.zoneRanges.forEach(function (zoneRange, i) {

--- a/views/js/admin/models/DPDZoneRangesData.js
+++ b/views/js/admin/models/DPDZoneRangesData.js
@@ -48,11 +48,11 @@ DPDZoneRangesData.prototype.addZoneRange = function (zoneRange)
  * @param {integer|string} zoneRangeId
  * @param {object} valueObject Object containing updated values
  */
-DPDZoneRangesData.prototype.updateZoneRange = function (zoneRangeId, valueObject) {
+DPDZoneRangesData.prototype.updateZoneRangeupdateZoneRange = function (zoneRangeId, valueObject) {
     var self = this;
 
     this.zoneRanges.forEach(function (zoneRange, i) {
-        if (zoneRange.id === zoneRangeId) {
+        if (zoneRange.id === parseInt(zoneRangeId)) {
             for (var property in valueObject) {
                 if (zoneRange.hasOwnProperty(property)) {
                     self.zoneRanges[i][property] = valueObject[property];


### PR DESCRIPTION
The problem was that we in condition are using strict comparisons and sometimes the zone range came as a string. Type hints also show int or string, but this was causing problems on zoneRange delete. It kept saving the old zoneRange list. 