### PR TITLE
Cast to int on removal zone.

### DIFF
--- a/views/js/admin/models/DPDZoneRangesData.js
+++ b/views/js/admin/models/DPDZoneRangesData.js
@@ -71,7 +71,7 @@ DPDZoneRangesData.prototype.removeZoneRange = function (zoneRangeId) {
     var self = this;
 
     this.zoneRanges.forEach(function (zoneRange, i) {
-        if (zoneRange.id === zoneRangeId) {
+        if (zoneRange.id === parseInt(zoneRangeId)) {
             self.zoneRanges.splice(i, 1);
         }
     });


### PR DESCRIPTION
After Q&A I got a report that it's still not working on deletion. After checking the fix again, I saw that I completely forgot to parse to int on the removal method.