### PR TITLE
DGS-221-Bug fix for initial order creation label return

### DIFF
--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -1127,7 +1127,7 @@ class DPDBaltics extends CarrierModule
             if ($isAutomated) {
                 if (!$shipment->return_pl_number) {
                     $shipmentService = $this->getModuleContainer('invertus.dpdbaltics.service.shipment_service');
-                    $shipmentService->createReturnServiceShipment(Config::RETURN_TEMPLATE_DEFAULT_ID, $shipment->id_order);
+                    $shipment= $shipmentService->createReturnServiceShipment(Config::RETURN_TEMPLATE_DEFAULT_ID, $shipment->id_order);
                 }
                 $parcelPrintResponse = $this->printConcatedLabels($shipment, $format, $position);
             } else {

--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -1127,7 +1127,7 @@ class DPDBaltics extends CarrierModule
             if ($isAutomated) {
                 if (!$shipment->return_pl_number) {
                     $shipmentService = $this->getModuleContainer('invertus.dpdbaltics.service.shipment_service');
-                    $shipment= $shipmentService->createReturnServiceShipment(Config::RETURN_TEMPLATE_DEFAULT_ID, $shipment->id_order);
+                    $shipment = $shipmentService->createReturnServiceShipment(Config::RETURN_TEMPLATE_DEFAULT_ID, $shipment->id_order);
                 }
                 $parcelPrintResponse = $this->printConcatedLabels($shipment, $format, $position);
             } else {


### PR DESCRIPTION
There was a bug after the initial order creation that on the print return label not printed. After checking out I saw that after updating the shipment and updating return label I never assigned the updated value to the shipment.