### PR TITLE
DGS-221/BulkAction-return-label-bug-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,3 +124,6 @@
 
 ## [3.2.11]
 - Sustainable logo added to DPD carrier text for older versions of theme
+
+## [3.2.12]
+- Print return label on initial order creation in bulk action and save&print bug fix

--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -116,7 +116,7 @@ class DPDBaltics extends CarrierModule
         $this->author = 'Invertus';
         $this->tab = 'shipping_logistics';
         $this->description = 'DPD Baltics shipping integration';
-        $this->version = '3.2.11';
+        $this->version = '3.2.12';
         $this->ps_versions_compliancy = ['min' => '1.7.1.0', 'max' => _PS_VERSION_];
         $this->need_instance = 0;
         parent::__construct();
@@ -1162,6 +1162,10 @@ class DPDBaltics extends CarrierModule
             $shipment = new DPDShipment($shipmentId);
             $plNumbers[] = $shipment->pl_number;
             if ($isAutomated) {
+                if(!$shipment->return_pl_number) {
+                    $shipmentService = $this->getModuleContainer('invertus.dpdbaltics.service.shipment_service');
+                    $shipment = $shipmentService->createReturnServiceShipment(Config::RETURN_TEMPLATE_DEFAULT_ID, $shipment->id_order);
+                }
                 $plNumbers[] = $shipment->return_pl_number;
             }
         }


### PR DESCRIPTION
One more bug with return labels. Return label print fix on bulk action after initial order creation. The same error appeared if an order is just created it did not have a return service. Added the same condition with return shipment creation.