### PR TITLE
Dgs 223/additional shipping costs

### DIFF
--- a/config/service.yml
+++ b/config/service.yml
@@ -69,7 +69,7 @@ services:
       - '@language'
       - '@shop'
 
-  invertus.dpdbaltics.service.price_calculation_service:
+  invertus.dpdbaltics.service.shipping_price_calculation_service:
     class: 'Invertus\dpdBaltics\Service\ShippingPriceCalculationService'
     arguments:
       - '@invertus.dpdbaltics.service.price_rule_service'

--- a/config/service.yml
+++ b/config/service.yml
@@ -69,6 +69,12 @@ services:
       - '@language'
       - '@shop'
 
+  invertus.dpdbaltics.service.price_calculation_service:
+    class: 'Invertus\dpdBaltics\Service\ShippingPriceCalculationService'
+    arguments:
+      - '@invertus.dpdbaltics.service.price_rule_service'
+      - '@invertus.dpdbaltics.repository.price_rule_repository'
+
   invertus.dpdbaltics.service.tab_service:
     class: 'Invertus\dpdBaltics\Service\TabService'
     arguments:

--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -550,9 +550,8 @@ class DPDBaltics extends CarrierModule
             );
         /** @var PriceRuleService $priceRuleService */
         $priceRuleService = $this->getModuleContainer()->get('invertus.dpdbaltics.service.price_rule_service');
-        $shippingCosts = $priceRuleService->applyPriceRuleForCarrier($cart, $priceRulesIds, $this->context->shop->id);
         $shippingPriceCalculationService = new ShippingPriceCalculationService();
-        return $shippingPriceCalculationService->calculateShippingCosts($cart, $shippingCosts);
+        return  $shippingPriceCalculationService->calculate($cart, $priceRuleService, $priceRulesIds);
     }
 
     public function hookDisplayCarrierExtraContent($params)

--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -539,19 +539,10 @@ class DPDBaltics extends CarrierModule
             }
         }
 
-        /** @var PriceRuleRepository $priceRuleRepository */
-        $priceRuleRepository = $this->getModuleContainer()->get('invertus.dpdbaltics.repository.price_rule_repository');
+        /** @var ShippingPriceCalculationService $shippingPriceCalculationService */
+        $shippingPriceCalculationService = $this->getModuleContainer()->get('invertus.dpdbaltics.service.price_calculation_service');
 
-        // Get all price rules for current carrier
-        $priceRulesIds =
-            $priceRuleRepository->getByCarrierReference(
-                $deliveryAddress,
-                $carrier->id_reference
-            );
-        /** @var PriceRuleService $priceRuleService */
-        $priceRuleService = $this->getModuleContainer()->get('invertus.dpdbaltics.service.price_rule_service');
-        $shippingPriceCalculationService = new ShippingPriceCalculationService();
-        return  $shippingPriceCalculationService->calculate($cart, $priceRuleService, $priceRulesIds);
+        return  $shippingPriceCalculationService->calculate($cart, $deliveryAddress);
     }
 
     public function hookDisplayCarrierExtraContent($params)

--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -550,8 +550,8 @@ class DPDBaltics extends CarrierModule
             );
         /** @var PriceRuleService $priceRuleService */
         $priceRuleService = $this->getModuleContainer()->get('invertus.dpdbaltics.service.price_rule_service');
-        $shippingPriceCalculationService = new ShippingPriceCalculationService();
         $shippingCosts = $priceRuleService->applyPriceRuleForCarrier($cart, $priceRulesIds, $this->context->shop->id);
+        $shippingPriceCalculationService = new ShippingPriceCalculationService();
         return $shippingPriceCalculationService->calculateShippingCosts($cart, $shippingCosts);
     }
 

--- a/dpdbaltics.php
+++ b/dpdbaltics.php
@@ -51,6 +51,7 @@ use Invertus\dpdBaltics\Service\Payment\PaymentService;
 use Invertus\dpdBaltics\Service\PriceRuleService;
 use Invertus\dpdBaltics\Service\PudoService;
 use Invertus\dpdBaltics\Service\ShipmentService;
+use Invertus\dpdBaltics\Service\ShippingPriceCalculationService;
 use Invertus\dpdBaltics\Service\TabService;
 use Invertus\dpdBaltics\Service\TrackingService;
 use Invertus\dpdBaltics\Util\CountryUtility;
@@ -549,8 +550,9 @@ class DPDBaltics extends CarrierModule
             );
         /** @var PriceRuleService $priceRuleService */
         $priceRuleService = $this->getModuleContainer()->get('invertus.dpdbaltics.service.price_rule_service');
-
-        return $priceRuleService->applyPriceRuleForCarrier($cart, $priceRulesIds, $this->context->shop->id);
+        $shippingPriceCalculationService = new ShippingPriceCalculationService();
+        $shippingCosts = $priceRuleService->applyPriceRuleForCarrier($cart, $priceRulesIds, $this->context->shop->id);
+        return $shippingPriceCalculationService->calculateShippingCosts($cart, $shippingCosts);
     }
 
     public function hookDisplayCarrierExtraContent($params)

--- a/src/Service/PriceRuleService.php
+++ b/src/Service/PriceRuleService.php
@@ -393,6 +393,7 @@ class PriceRuleService
             if (!$this->priceRuleRepository->isAvailableInShop($priceRuleId, $shopId)) {
                 return false;
             }
+
             $priceRule = new DPDPriceRule($priceRuleId, null, $shopId);
             // Check if price rule is applicable for this cart
             if ($priceRule->isApplicableForCart($cart)) {

--- a/src/Service/PriceRuleService.php
+++ b/src/Service/PriceRuleService.php
@@ -394,7 +394,6 @@ class PriceRuleService
                 return false;
             }
             $priceRule = new DPDPriceRule($priceRuleId, null, $shopId);
-            $priceRule->price += $this->getAdditionalShippingCosts($cart);
             // Check if price rule is applicable for this cart
             if ($priceRule->isApplicableForCart($cart)) {
                 // If it's applicable - use price rule's price and don't check other price rules
@@ -425,24 +424,5 @@ class PriceRuleService
         }
 
         return true;
-    }
-
-    /**
-     * @param Cart $cart
-     *
-     * @return float|null
-     */
-    private function getAdditionalShippingCosts(Cart $cart)
-    {
-        $products = $cart->getProducts();
-        $additionalShippingCosts = 0;
-
-        foreach ($products as $product) {
-            if($product['additional_shipping_cost']) {
-                $additionalShippingCosts += $product['additional_shipping_cost'];
-            }
-        }
-
-        return $additionalShippingCosts;
     }
 }

--- a/src/Service/PriceRuleService.php
+++ b/src/Service/PriceRuleService.php
@@ -393,7 +393,6 @@ class PriceRuleService
             if (!$this->priceRuleRepository->isAvailableInShop($priceRuleId, $shopId)) {
                 return false;
             }
-
             $priceRule = new DPDPriceRule($priceRuleId, null, $shopId);
             // Check if price rule is applicable for this cart
             if ($priceRule->isApplicableForCart($cart)) {

--- a/src/Service/PriceRuleService.php
+++ b/src/Service/PriceRuleService.php
@@ -23,6 +23,7 @@ namespace Invertus\dpdBaltics\Service;
 
 use Carrier;
 use Cart;
+use Context;
 use DPDBaltics;
 use DPDPriceRule;
 use Invertus\dpdBaltics\Repository\CarrierRepository;
@@ -424,5 +425,16 @@ class PriceRuleService
         }
 
         return true;
+    }
+
+    public function applyAdditionalCosts(Cart $cart, array $priceRulesIds, float $additionalShippingCosts) {
+
+        $shippingPrice = 0.0;
+
+        $shippingPrice += $this->applyPriceRuleForCarrier($cart, $priceRulesIds, Context::getContext()->shop->id);
+
+        $shippingPrice += $additionalShippingCosts;
+
+        return $shippingPrice;
     }
 }

--- a/src/Service/PriceRuleService.php
+++ b/src/Service/PriceRuleService.php
@@ -426,15 +426,4 @@ class PriceRuleService
 
         return true;
     }
-
-    public function applyAdditionalCosts(Cart $cart, array $priceRulesIds, float $additionalShippingCosts) {
-
-        $shippingPrice = 0.0;
-
-        $shippingPrice += $this->applyPriceRuleForCarrier($cart, $priceRulesIds, Context::getContext()->shop->id);
-
-        $shippingPrice += $additionalShippingCosts;
-
-        return $shippingPrice;
-    }
 }

--- a/src/Service/PriceRuleService.php
+++ b/src/Service/PriceRuleService.php
@@ -21,7 +21,6 @@
 
 namespace Invertus\dpdBaltics\Service;
 
-use Address;
 use Carrier;
 use Cart;
 use DPDBaltics;
@@ -36,7 +35,6 @@ use Language;
 use Module;
 use Shop;
 use Smarty;
-use TaxManagerFactory;
 use Tools;
 use Validate;
 

--- a/src/Service/PriceRuleService.php
+++ b/src/Service/PriceRuleService.php
@@ -21,6 +21,7 @@
 
 namespace Invertus\dpdBaltics\Service;
 
+use Address;
 use Carrier;
 use Cart;
 use DPDBaltics;
@@ -35,6 +36,7 @@ use Language;
 use Module;
 use Shop;
 use Smarty;
+use TaxManagerFactory;
 use Tools;
 use Validate;
 
@@ -394,7 +396,7 @@ class PriceRuleService
                 return false;
             }
             $priceRule = new DPDPriceRule($priceRuleId, null, $shopId);
-
+            $priceRule->price += $this->getAdditionalShippingCosts($cart);
             // Check if price rule is applicable for this cart
             if ($priceRule->isApplicableForCart($cart)) {
                 // If it's applicable - use price rule's price and don't check other price rules
@@ -425,5 +427,24 @@ class PriceRuleService
         }
 
         return true;
+    }
+
+    /**
+     * @param Cart $cart
+     *
+     * @return float|null
+     */
+    private function getAdditionalShippingCosts(Cart $cart)
+    {
+        $products = $cart->getProducts();
+        $additionalShippingCosts = 0;
+
+        foreach ($products as $product) {
+            if($product['additional_shipping_cost']) {
+                $additionalShippingCosts += $product['additional_shipping_cost'];
+            }
+        }
+
+        return $additionalShippingCosts;
     }
 }

--- a/src/Service/ShippingPriceCalculationService.php
+++ b/src/Service/ShippingPriceCalculationService.php
@@ -26,20 +26,21 @@ class ShippingPriceCalculationService
 {
     /**
      * @param Cart $cart
-     * @param float $shippingCosts
+     * @param PriceRuleService $priceRuleService
+     * @param array<string, string> $priceRulesIds
      *
      * @return float
      */
-    public function calculateShippingCosts(Cart $cart, float $shippingCosts)
+    public function calculate(Cart $cart, PriceRuleService $priceRuleService, array $priceRulesIds)
     {
         $products = $cart->getProducts();
-
+        $additionalShippingCosts = 0.0;
         foreach ($products as $product) {
-            if($product['additional_shipping_cost']) {
-                $shippingCosts += (float) $product['additional_shipping_cost'];
+            if((float) $product['additional_shipping_cost']) {
+                $additionalShippingCosts += (float) $product['additional_shipping_cost'];
             }
         }
 
-        return $shippingCosts;
+        return $priceRuleService->applyAdditionalCosts($cart, $priceRulesIds, $additionalShippingCosts);
     }
 }

--- a/src/Service/ShippingPriceCalculationService.php
+++ b/src/Service/ShippingPriceCalculationService.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace Invertus\dpdBaltics\Service;
+
+use Cart;
+
+class ShippingPriceCalculationService
+{
+    /**
+     * @param Cart $cart
+     * @param float $shippingCosts
+     *
+     * @return float
+     */
+    public function calculateShippingCosts(Cart $cart, float $shippingCosts)
+    {
+        $products = $cart->getProducts();
+
+        foreach ($products as $product) {
+            if($product['additional_shipping_cost']) {
+                $shippingCosts += (float) $product['additional_shipping_cost'];
+            }
+        }
+
+        return $shippingCosts;
+    }
+}


### PR DESCRIPTION
Feel free to correct me since I was not sure if this is the right approach to apply product additional shipping costs for the carrier. In my opinion, it looked logical since it applies to dpd carrier price rule where the set shipping cost is.

It basically takes products from a cart search for additional shipping costs and applies it to dpd carrier price rule.

Two products with additional shipping prices 100 and 50 euros + dpd carrier price rule have set 5 euros shipping costs
![image](https://user-images.githubusercontent.com/97019420/205255104-84fbc817-f67f-4876-8ee9-1b89aecf5346.png)
![image](https://user-images.githubusercontent.com/97019420/205255243-2e246ef3-d341-44ac-8950-07fa754c8844.png)

I am not sure if that was the correct approach so if that was the wrong approach will be waiting for advice.