### PR TITLE
DGS-271 Error on pudo orders with incorrect post code

### DIFF
--- a/src/Service/API/ShipmentApiService.php
+++ b/src/Service/API/ShipmentApiService.php
@@ -102,6 +102,13 @@ class ShipmentApiService
         $postCode = $address->postcode;
         $hasAddressFields = (bool) !$postCode || !$firstName || !$address->city || !$country;
 
+        // Post code might be wrong in order adress, so we set terminal post code instead
+        if ($shipmentData->isPudo()) {
+            $parcel = $this->parcelShopService->getParcelShopByShopId($shipmentData->getSelectedPudoId());
+            $selectedParcel = is_array($parcel) ? reset($parcel) : $parcel;
+            $postCode = $selectedParcel->getPCode();
+        }
+
         // IF prestashop allows, we take selected parcel terminal address in case information is missing in checkout address in specific cases.
         if (($hasAddressFields) && $shipmentData->isPudo()) {
             $parcel = $this->parcelShopService->getParcelShopByShopId($shipmentData->getSelectedPudoId());

--- a/src/Service/API/ShipmentApiService.php
+++ b/src/Service/API/ShipmentApiService.php
@@ -111,10 +111,7 @@ class ShipmentApiService
 
         // IF prestashop allows, we take selected parcel terminal address in case information is missing in checkout address in specific cases.
         if (($hasAddressFields) && $shipmentData->isPudo()) {
-            $parcel = $this->parcelShopService->getParcelShopByShopId($shipmentData->getSelectedPudoId());
-            $selectedParcel = is_array($parcel) ? reset($parcel) : $parcel;
             $firstName = $selectedParcel->getCompany();
-            $postCode = $selectedParcel->getPCode();
             $address->address1 = $selectedParcel->getStreet();
             $address->city = $selectedParcel->getCity();
             $country = $selectedParcel->getCountry();


### PR DESCRIPTION
Fixes this ticket [DGS-271](https://invertus.atlassian.net/browse/DGS-271).

| Questions         | Answers                                                                                                                                                                                     |
|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Description?      | After order is created with incorrect post code and parcel type is pudo, api returns error message that post code is incorrect. On pudo order we do not care what postcode user is typed. This fix is checking is order pudo and sets postcode of the pickup  point terminal|
| How to test?      | On BO go to `International->locations->Countries` select country you going to do order from and edit its   `Zip/Postal code format` to incorrect for that country. Make an order and try to print label.                                                                                                                

[DGS-271]: https://invertus.atlassian.net/browse/DGS-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ